### PR TITLE
Fix wrong error in draft documents

### DIFF
--- a/Zeplin/Export Selected Artboards.sketchplugin
+++ b/Zeplin/Export Selected Artboards.sketchplugin
@@ -3,7 +3,7 @@
 (function () {
     try {
         if ([doc isDraft]) {
-            [doc saveDocumentWithDelegate:nil didSaveSelector:NULL contextInfo:NULL];
+            [doc saveDocumentWithDelegate:nil didSaveSelector:nil contextInfo:nil];
             
             [doc showMessage:@"Please save the document before exporting."];
             return;


### PR DESCRIPTION
Changing `NULL`s to `nil` fixed the issue. :+1: 