### PR TITLE
Save document before handing it off to Zeplin

### DIFF
--- a/Zeplin/Export Selected Artboards.sketchplugin
+++ b/Zeplin/Export Selected Artboards.sketchplugin
@@ -2,11 +2,18 @@
 
 (function () {
     try {
-        if ([doc isDraft]) {
-            [doc saveDocumentWithDelegate:nil didSaveSelector:nil contextInfo:nil];
-            
-            [doc showMessage:@"Please save the document before exporting."];
+        if (![doc fileURL] || [doc isDraft]) {
+            [NSApp displayDialog:@"Please save the document before exporting to Zeplin." withTitle:@"Document not saved"];
             return;
+        }
+        
+        if ([doc isDocumentEdited]) {
+            [doc showMessage:@"Saving document…"];
+            
+            [doc saveDocument:nil];
+            while ([doc isDocumentEdited]) {
+                [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
+            }
         }
         
         var artboardIds = [[context valueForKey:@"selection"] valueForKeyPath:@"parentArtboard.@distinctUnionOfObjects.objectID"];
@@ -26,7 +33,7 @@
         validArtboardIds = nil;
         
         if (![artboardIds count]) {
-            [doc showMessage:@"Please select artboards you want to export."];
+            [NSApp displayDialog:@"Please select the artboards you want to export to Zeplin.\n\n☝️ Selecting a layer inside the artboard should be enough." withTitle:@"No artboard selected"];
             return;
         }
         
@@ -54,9 +61,9 @@
         
         var workspace = [NSWorkspace sharedWorkspace];
         
-        var applicationPath = [workspace absolutePathForAppBundleWithIdentifier:"io.zeplin.osx"];
+        var applicationPath = [workspace absolutePathForAppBundleWithIdentifier:@"io.zeplin.osx"];
         if (!applicationPath) {
-            [doc showMessage:@"Could not find Zeplin, make sure you installed and launched it: https://zpl.io/download"];
+            [NSApp displayDialog:@"Please make sure that you installed and launched it: https://zpl.io/download" withTitle:"Could not find Zeplin"];
             return;
         }
         
@@ -68,7 +75,7 @@
         applicationPath = nil;
         path = nil;
     } catch (err) {
-        [doc showMessage:@"Could not export artboards, please make sure that you have the latest version of Sketch!"];
+        [NSApp displayDialog:@"Exporting artboards failed with error:\n\n" + err + "\n\n🔧Please make sure that you have the latest versions of Zeplin and Sketch. Let us know if the issue continues: support@zeplin.io" withTitle:@"Could not export artboards"];
         log(err);
     }
 }());


### PR DESCRIPTION
Saving the document before handing it off to Zeplin, also changed errors to show dialogs instead of messages.