### PR TITLE
Only export `MSArtboardGroup`s

### DIFF
--- a/Zeplin.sketchplugin/Contents/Sketch/export.cocoascript
+++ b/Zeplin.sketchplugin/Contents/Sketch/export.cocoascript
@@ -30,11 +30,20 @@ var onRun = function (context) {
     var artboardIds = [[context valueForKey:@"selection"] valueForKeyPath:@"parentArtboard.@distinctUnionOfObjects.objectID"];
     
     var validArtboardIds = [NSMutableArray array];
-    var loop = [artboardIds objectEnumerator];
-    while (artboardId = [loop nextObject]) {
-        if ([artboardId isKindOfClass:[NSString class]]) {
-            [validArtboardIds addObject:artboardId];
+    var loop = [[[doc currentPage] artboards] objectEnumerator];
+    while (artboard = [loop nextObject]) {
+        if (![artboard isMemberOfClass:[MSArtboardGroup class]]) {
+            continue;
         }
+        
+        var artboardId = [artboard objectID];
+        if (![artboardIds containsObject:artboardId]) {
+            artboardId = nil
+            continue;
+        }
+        
+        [validArtboardIds addObject:artboardId];
+        artboardId = nil
     }
     
     loop = nil;


### PR DESCRIPTION
Sketch 3.7 introduced “Symbols” where an artboard can now be an `MSSymbolMaster` instance. This pull request makes sure that the selected artboards for exporting are `MSArtboardGroup` instances only.

Symbols might be exported later on as “common UI elements” but that’s a feature for another day. :surfer: 