### PR TITLE
[ZDI-193] Collect `shareId` for cloud documents

### DIFF
--- a/Zeplin.sketchplugin/Contents/Sketch/utils.cocoascript
+++ b/Zeplin.sketchplugin/Contents/Sketch/utils.cocoascript
@@ -168,6 +168,16 @@ var writeDirectives = function (directives, path) {
     return path;
 }
 
+var getShareId = function (context) {
+    try {
+        return context.document.cloudShare().shortID();
+    } catch (error) {
+        log("Getting cloud file “shortID” failed with error “" + error + "”."));
+    }
+
+    return nil;
+}
+
 var launchZeplin = function (context, path) {
     var doc = context.document;
     var workspace = [NSWorkspace sharedWorkspace];
@@ -189,6 +199,7 @@ var launchZeplin = function (context, path) {
 
 var exportArtboards = function (context, artboards, temporaryPath) {
     var doc = context.document;
+    var shareId = getShareId(context);
 
     var foreignSymbolsUpToDate = true;
     // `MSBadgeController` is defined on Sketch 44, `activeWindowBadgingActions` is defined on Sketch 46.
@@ -297,6 +308,11 @@ var exportArtboards = function (context, artboards, temporaryPath) {
     [directives setObject:artboardNamesByIdentifier forKey:@"artboardNames"];
     [directives setObject:containsArtboard forKey:@"containsArtboard"];
 
+    if (shareId) {
+        [directives setObject:shareId forKey:@"shareId"];
+    }
+
+    shareId = nil;
     artboardIds = nil;
     pageIds = nil;
     uniqueArtboardSizes = nil;


### PR DESCRIPTION
## Change description

With this PR, we are starting to collect the `cloudShare` identifier and passing it onto the Mac App as a new directive, so the Mac App will be able to reproduce and display the URL to the original cloud file. 

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [ZDI-193](https://zeplin.atlassian.net/browse/ZDI-193) 

## Checklists

### Development

- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
