### PR TITLE
Collect `sourceFileName`s in exports

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,3 @@
-## Jira Task
-
-Task: [ZDI-X](https://zeplin.atlassian.net/browse/ZDI-X)
-
 ## Summary of the changes
 
 The changes in this PR include
@@ -16,7 +12,6 @@ Ask yourself the questions below and write their answers if needed:
 ## Checklist
 
 - [ ] My PR has a clear and complete description.
-- [ ] My PR contains a link to the JIRA task.
 - [ ] I have performed a self-review of my own code.
 - [ ] I have considered the security implications of this change.
 - [ ] I have tested the changes against older versions of Sketch.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,22 @@
-## Change description
+## Jira Task
 
-> Description here
+Task: [ZDI-X](https://zeplin.atlassian.net/browse/ZDI-X)
 
-## Type of change
-- [ ] Bug fix (fixes an issue)
-- [ ] New feature (adds functionality)
+## Summary of the changes
 
-## Related issues
+The changes in this PR include
 
-> Fix [#1]() 
+- [ ] ...
 
-## Checklists
+Ask yourself the questions below and write their answers if needed:
 
-### Development
+- Is there anything important to consider while reviewing?
+- Do you need to do any additional development or fixes before merging this PR?
 
-- [ ] Lint rules pass locally
-- [ ] Application changes have been tested thoroughly
-- [ ] Automated tests covering modified code pass
+## Checklist
 
-### Security
-
-- [ ] Security impact of change has been considered
-- [ ] Code follows company security practices and guidelines
-
-### Code review 
-
-- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
-- [ ] "Ready for review" label attached and reviewers assigned
-- [ ] Changes have been reviewed by at least one other contributor
-- [ ] Pull request linked to task tracker where applicable
+- [ ] My PR has a clear and complete description.
+- [ ] My PR contains a link to the JIRA task.
+- [ ] I have performed a self-review of my own code.
+- [ ] I have considered the security implications of this change.
+- [ ] I have tested the changes against older versions of Sketch.

--- a/Zeplin.sketchplugin/Contents/Sketch/utils.cocoascript
+++ b/Zeplin.sketchplugin/Contents/Sketch/utils.cocoascript
@@ -178,6 +178,14 @@ var getShareId = function (context) {
     return nil;
 }
 
+var getSourceFileName = function (context) {
+    try {
+        return context.document.displayName();
+    } catch (error) {
+        log("Getting source file name failed with error “" + error + "”."));
+    }
+}
+
 var launchZeplin = function (context, path) {
     var doc = context.document;
     var workspace = [NSWorkspace sharedWorkspace];
@@ -200,6 +208,7 @@ var launchZeplin = function (context, path) {
 var exportArtboards = function (context, artboards, temporaryPath) {
     var doc = context.document;
     var shareId = getShareId(context);
+    var sourceFileName = getSourceFileName(context);
 
     var foreignSymbolsUpToDate = true;
     // `MSBadgeController` is defined on Sketch 44, `activeWindowBadgingActions` is defined on Sketch 46.
@@ -310,6 +319,10 @@ var exportArtboards = function (context, artboards, temporaryPath) {
 
     if (shareId) {
         [directives setObject:shareId forKey:@"shareId"];
+    }
+
+    if (sourceFileName) {
+        [directives setObject:sourceFileName forKey:@"sourceFileName"];
     }
 
     shareId = nil;

--- a/Zeplin.sketchplugin/Contents/Sketch/utils.cocoascript
+++ b/Zeplin.sketchplugin/Contents/Sketch/utils.cocoascript
@@ -184,6 +184,8 @@ var getSourceFileName = function (context) {
     } catch (error) {
         log("Getting source file name failed with error “" + error + "”."));
     }
+
+    return nil;
 }
 
 var launchZeplin = function (context, path) {
@@ -326,6 +328,7 @@ var exportArtboards = function (context, artboards, temporaryPath) {
     }
 
     shareId = nil;
+    sourceFileName = nil;
     artboardIds = nil;
     pageIds = nil;
     uniqueArtboardSizes = nil;


### PR DESCRIPTION
## Summary of the changes

The changes in this PR include

- [x] Read `displayName` off of `MSDocument` and write in the directives for the Mac App to read.
- [x] Update the pull request template so that it'd be more relevant to the codebase

## Checklist

- [x] My PR has a clear and complete description.
- [x] I have performed a self-review of my own code.
- [x] I have considered the security implications of this change.
- [x] I have tested the changes against older versions of Sketch.