### PR TITLE
Catch `CGRect` error on macOS Ventura 13.0

### DIFF
--- a/Zeplin.sketchplugin/Contents/Sketch/utils.cocoascript
+++ b/Zeplin.sketchplugin/Contents/Sketch/utils.cocoascript
@@ -1,21 +1,28 @@
 var isSelectionExportable = function (artboards) {
-    var artboardPixelLimit = 1000000000; // 1e9
     var overSizedArtboardName = nil;
+    // `size` on `CGRect` fails on Mocha, on macOS 13.0 same as macOS 10.13, Sketch 45 and below.
+    try {
+        var artboardPixelLimit = 1000000000; // 1e9
 
-    var artboardsLoop = [artboards objectEnumerator];
-    var artboard = nil;
-    while (artboard = [artboardsLoop nextObject]) {
-        var artboardSize = artboard.rect().size;
-        if (artboardSize.width * artboardSize.height > artboardPixelLimit) {
-            overSizedArtboardName = artboard.name();
-            break;
+        var artboardsLoop = [artboards objectEnumerator];
+        var artboard = nil;
+        while (artboard = [artboardsLoop nextObject]) {
+            var artboardSize = artboard.rect().size;
+            if (artboardSize.width * artboardSize.height > artboardPixelLimit) {
+                overSizedArtboardName = artboard.name();
+                break;
+            }
         }
-    }
 
-    artboardSize = nil;
-    artboard = nil;
-    artboardsLoop = nil;
-    artboardPixelLimit = nil;
+        artboardSize = nil;
+        artboard = nil;
+        artboardsLoop = nil;
+        artboardPixelLimit = nil;
+    } catch (error) {
+        log("Checking oversized artboards failed with error “" + error + "”.");
+
+        return true;
+    }
 
     if (overSizedArtboardName) {
         [NSApp displayDialog:@"Selected artboard “" + overSizedArtboardName + "” is too large to export. Due to a limitation in Sketch, it’s only possible to export artboards smaller than 30,000 px ⨉ 30,000 px.\n\n☝️ You can divide the artboard into multiple artboards and export again." withTitle:@"Artboard too large"];
@@ -266,7 +273,7 @@ var exportArtboards = function (context, artboards, temporaryPath) {
     artboardsLoop = nil;
 
     var uniqueArtboardSizes = [];
-    // `size` on `CGRect` fails on Mocha, on macOS 10.13, Sketch 45 and below.
+    // `size` on `CGRect` fails on Mocha, on macOS 13.0 same as macOS 10.13, Sketch 45 and below.
     try {
         var loop = [artboards objectEnumerator];
         var artboard = nil;


### PR DESCRIPTION
## Summary of the changes

`size` on `CGRect` fails on Mocha, on macOS Ventura 13.0. 

⚠️ Until this issue has been fixed on new versions, the plugin can't warn designers about oversized artboards that could not be exported because of Sketch's limits.

## Checklist

- [x] My PR has a clear and complete description.
- [x] I have performed a self-review of my own code.
- [x] I have considered the security implications of this change.
- [x] I have tested the changes against older versions of Sketch.
